### PR TITLE
Bringing over some improvements

### DIFF
--- a/engine/framesnapshot.h
+++ b/engine/framesnapshot.h
@@ -166,6 +166,7 @@ public:
 private:
 	void	DeleteFrameSnapshot( CFrameSnapshot* pSnapshot );
 
+	CThreadFastMutex									m_FrameSnapshotsWriteMutex;
 	CUtlLinkedList<CFrameSnapshot*, unsigned short>		m_FrameSnapshots;
 	CClassMemoryPool< PackedEntity >					m_PackedEntitiesPool;
 

--- a/engine/sv_framesnapshot.cpp
+++ b/engine/sv_framesnapshot.cpp
@@ -100,7 +100,9 @@ CFrameSnapshot*	CFrameSnapshotManager::CreateEmptySnapshot( int tickcount, int m
 		entry++;
 	}
 
+	m_FrameSnapshotsWriteMutex.Lock();
 	snap->m_ListIndex = m_FrameSnapshots.AddToTail( snap );
+	m_FrameSnapshotsWriteMutex.Unlock();
 	return snap;
 }
 
@@ -190,7 +192,9 @@ void CFrameSnapshotManager::DeleteFrameSnapshot( CFrameSnapshot* pSnapshot )
 		}
 	}
 
+	m_FrameSnapshotsWriteMutex.Lock();
 	m_FrameSnapshots.Remove( pSnapshot->m_ListIndex );
+	m_FrameSnapshotsWriteMutex.Unlock();
 	delete pSnapshot;
 }
 

--- a/engine/sv_main.cpp
+++ b/engine/sv_main.cpp
@@ -1788,7 +1788,9 @@ void CGameServer::CopyTempEntities( CFrameSnapshot* pSnapshot )
 //   are running many instances anyway. It's off in Dota and CSGO dedicated servers.
 //
 // Bruce also had a patch to disable this in //ValveGames/staging/game/tf/cfg/unencrypted/print_instance_config.py
-static ConVar sv_parallel_sendsnapshot( "sv_parallel_sendsnapshot", "0" );
+//
+// NOTE: The crash should be fixed.
+static ConVar sv_parallel_sendsnapshot( "sv_parallel_sendsnapshot", "1" );
 
 static void SV_ParallelSendSnapshot( CGameClient *& pClient )
 {

--- a/filesystem/basefilesystem.cpp
+++ b/filesystem/basefilesystem.cpp
@@ -4180,23 +4180,17 @@ bool CBaseFileSystem::FixUpPath( const char *pFileName, char *pFixedUpFileName, 
 	}
 	else 
 	{
-		//  Get the BASE_PATH, skip past  - if necessary, and lowercase the rest
-		//  Not just yet...
-
-
-		int iBaseLength = 0;
-		char pBaseDir[MAX_PATH];
-
 		//  Need to get "BASE_PATH" from the filesystem paths, and then check this name against it.
-		//
-		iBaseLength = GetSearchPath( "BASE_PATH", true, pBaseDir, sizeof( pBaseDir ) );
-		if ( iBaseLength )
+		if ( m_iBaseLength < 3 ) // If It's below 3 it's most likely empty. So we try again. (GetSearchPath never returns 0?)
+			m_iBaseLength = GetSearchPath( "BASE_PATH", true, m_pBaseDir, sizeof( m_pBaseDir ) );
+
+		if ( m_iBaseLength > 3 )
 		{
 			//  If the first part of the pFixedUpFilename is pBaseDir
 			//  then lowercase the part after that.
-			if ( *pBaseDir && (iBaseLength+1 < V_strlen( pFixedUpFileName ) ) && (0 != V_strncmp( pBaseDir, pFixedUpFileName, iBaseLength ) )  )
+			if ( *m_pBaseDir && (m_iBaseLength+1 < V_strlen( pFixedUpFileName ) ) && (0 != V_strncmp( m_pBaseDir, pFixedUpFileName, m_iBaseLength ) )  )
 			{
-				V_strlower( &pFixedUpFileName[iBaseLength-1] );
+				V_strlower( &pFixedUpFileName[m_iBaseLength-1] );
 			}
 		}
 	    

--- a/filesystem/basefilesystem.h
+++ b/filesystem/basefilesystem.h
@@ -850,6 +850,9 @@ protected:
 	/// Remove a custom fetch job from the list (and release our reference)
 	friend class CFileAsyncReadJob;
 	void RemoveAsyncCustomFetchJob( CFileAsyncReadJob *pJob );
+
+	char m_pBaseDir[MAX_PATH];
+	int m_iBaseLength;
 };
 
 inline const CUtlSymbol& CBaseFileSystem::CPathIDInfo::GetPathID() const

--- a/game/client/c_baseanimating.cpp
+++ b/game/client/c_baseanimating.cpp
@@ -789,6 +789,12 @@ C_BaseAnimating::~C_BaseAnimating()
 		m_pAttachedTo->RemoveBoneAttachment( this );
 		m_pAttachedTo = NULL;
 	}
+
+	if ( m_pScaledCollidable )
+	{
+		UTIL_RemoveScaledPhysCollide( m_pScaledCollidable );
+		m_pScaledCollidable = NULL;
+	}
 }
 
 bool C_BaseAnimating::UsesPowerOfTwoFrameBufferTexture( void )
@@ -5157,9 +5163,18 @@ void C_BaseAnimating::Simulate()
 	}
 }
 
-
 bool C_BaseAnimating::TestCollision( const Ray_t &ray, unsigned int fContentsMask, trace_t& tr )
 {
+	if ( GetModelScale() != 1.0f )
+	{
+		if ( m_pScaledCollidable != NULL )
+		{
+			physcollision->TraceBox( ray, m_pScaledCollidable, GetAbsOrigin(), GetAbsAngles(), &tr );
+		
+			return tr.DidHit();
+		}
+	}
+
 	if ( ray.m_IsRay && IsSolidFlagSet( FSOLID_CUSTOMRAYTEST ))
 	{
 		if (!TestHitboxes( ray, fContentsMask, tr ))
@@ -6705,4 +6720,23 @@ void C_BaseAnimating::MoveBoneAttachments( C_BaseAnimating* attachTarget )
 			m_BoneAttachments.Remove(0);
 		}
 	}
+}
+
+//-----------------------------------------------------------------------------
+// Purpose: Update Collisions. (Same way it's done serverside. We only update it when Activate is called)
+//-----------------------------------------------------------------------------
+void C_BaseAnimating::Activate()
+{
+	if ( GetModelScale() != 1.0f )
+	{
+		if ( m_pScaledCollidable )
+		{
+			UTIL_RemoveScaledPhysCollide( m_pScaledCollidable );
+			m_pScaledCollidable = NULL;
+		}
+
+		m_pScaledCollidable = UTIL_GetScaledPhysCollide( GetModelIndex(), GetModelScale() );
+	}
+
+	BaseClass::Activate();
 }

--- a/game/client/c_baseanimating.h
+++ b/game/client/c_baseanimating.h
@@ -449,6 +449,7 @@ public:
 
 	virtual bool					IsViewModel() const;
 	void					UpdateOnRemove( void ) override;
+	virtual void					Activate( void );
 
 protected:
 	// View models scale their attachment positions to account for FOV. To get the unmodified
@@ -640,6 +641,9 @@ private:
 	mutable MDLHandle_t				m_hStudioHdr;
 	CThreadFastMutex				m_StudioHdrInitLock;
 	bool							m_bHasAttachedParticles;
+
+private:
+	CPhysCollide					*m_pScaledCollidable;
 };
 
 enum 

--- a/game/client/c_baseentity.cpp
+++ b/game/client/c_baseentity.cpp
@@ -459,6 +459,7 @@ BEGIN_RECV_TABLE_NOBASE(C_BaseEntity, DT_BaseEntity)
 	RecvPropInt(RECVINFO(m_CollisionGroup)),
 	RecvPropFloat(RECVINFO(m_flElasticity)),
 	RecvPropFloat(RECVINFO(m_flShadowCastDistance)),
+	RecvPropFloat(RECVINFO(m_flGravity)),
 	RecvPropEHandle( RECVINFO(m_hOwnerEntity) ),
 	RecvPropEHandle( RECVINFO(m_hEffectEntity) ),
 	RecvPropInt( RECVINFO_NAME(m_hNetworkMoveParent, moveparent), 0, RecvProxy_IntToMoveParent ),

--- a/game/client/c_baseentity.h
+++ b/game/client/c_baseentity.h
@@ -1709,6 +1709,9 @@ protected:
 
 private:
 	bool	m_bOldShouldDraw;
+
+public:
+	virtual void					OnModelChange( int oldModelIndex, int newModelIndex ) {};
 };
 
 EXTERN_RECV_TABLE(DT_BaseEntity);

--- a/game/client/cdll_util.cpp
+++ b/game/client/cdll_util.cpp
@@ -28,6 +28,10 @@
 #include "view.h"
 #include "ixboxsystem.h"
 #include "inputsystem/iinputsystem.h"
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+#include <vprof.h>
 
 // memdbgon must be the last include file in a .cpp file!!!
 #include "tier0/memdbgon.h"
@@ -1314,4 +1318,128 @@ bool UTIL_HasLoadedAnyMap()
 		return false;
 
 	return g_pFullFileSystem->FileExists( szFilename, "MOD" );
+}
+
+struct CPhysEntry
+{
+	int references = 1;
+	int modelIndex = 0;
+	float scale = 1.0f;
+};
+
+std::unordered_map<CPhysCollide*, CPhysEntry> g_pScaledReferences;
+std::unordered_map<int, std::unordered_map<float, CPhysCollide*>*> g_pScaledCollidables;
+CPhysCollide *UTIL_GetScaledPhysCollide( int modelIndex, float scale ) // Based off UTIL_CreateScaledPhysObject
+{
+	VPROF( "UTIL_GetScaledPhysCollide", VPROF_BUDGETGROUP_PHYSICS );
+
+	if (scale == 1.0f)
+		return NULL;
+
+	std::unordered_map<float, CPhysCollide*>* scaledCollidables = nullptr;
+	auto iModel = g_pScaledCollidables.find( modelIndex );
+	if ( iModel != g_pScaledCollidables.end() )
+	{
+		std::unordered_map<float, CPhysCollide*>* collidables = iModel->second;
+		auto iCollidable = collidables->find( scale );
+		if ( iCollidable != collidables->end() )
+		{
+			auto it = g_pScaledReferences.find( iCollidable->second );
+			if ( it != g_pScaledReferences.end() )
+			{
+				++it->second.references;
+			} else {
+				DevWarning( "UTIL_GetScaledPhysCollide: Failed to find reference counter!\n" );
+			}
+
+			return iCollidable->second;
+		} else {
+			scaledCollidables = collidables;
+		}
+	} else {
+		scaledCollidables = new std::unordered_map<float, CPhysCollide*>;
+		g_pScaledCollidables[modelIndex] = scaledCollidables;
+	}
+
+	ICollisionQuery *pQuery = physcollision->CreateQueryModel( modelinfo->GetVCollide( modelIndex )->solids[0] );
+	if ( pQuery == NULL )
+	{
+		Warning( "UTIL_GetScaledPhysCollide: Failed to created scaled CPhysCollide for model %s!\n", modelinfo->GetModelName( modelinfo->GetModel( modelIndex ) ) );
+		return NULL;
+	}
+
+	const int nNumConvex = pQuery->ConvexCount();
+	CPhysPolysoup *pPolySoups = physcollision->PolysoupCreate();
+
+	for ( int i = 0; i < nNumConvex; ++i )
+	{
+		int nNumTris = pQuery->TriangleCount( i );
+		int nNumVerts = nNumTris * 3;
+
+		Vector *pVerts = (Vector *) stackalloc( sizeof(Vector) * nNumVerts );
+		for ( int j = 0; j < nNumTris; ++j )
+		{
+			int p = j*3;
+			pQuery->GetTriangleVerts( i, j, pVerts+p );
+			*(pVerts+p) *= scale;
+			*(pVerts+p+1) *= scale;
+			*(pVerts+p+2) *= scale;
+		}
+
+		for ( int j = 0; j < nNumVerts; j += 3 )
+		{
+			physcollision->PolysoupAddTriangle( pPolySoups, pVerts[j], pVerts[j + 1], pVerts[j + 2], 0 );
+		}
+	}
+
+	physcollision->DestroyQueryModel( pQuery );
+
+	CPhysCollide* physCollide = physcollision->ConvertPolysoupToCollide( pPolySoups, true );
+	physcollision->PolysoupDestroy( pPolySoups );
+	if ( physCollide == NULL )
+	{
+		Warning( "UTIL_GetScaledPhysCollide: Failed to created scaled CPhysCollide for model %s %f!\n", modelinfo->GetModelName( modelinfo->GetModel( modelIndex ) ), scale );
+		return NULL;
+	}
+
+	(*scaledCollidables)[scale] = physCollide;
+
+	CPhysEntry entry;
+	entry.modelIndex = modelIndex;
+	entry.scale = scale;
+	g_pScaledReferences[physCollide] = entry;
+
+	return physCollide;
+}
+
+void UTIL_RemoveScaledPhysCollide( CPhysCollide *physCollide )
+{
+	VPROF( "UTIL_RemoveScaledPhysCollide", VPROF_BUDGETGROUP_PHYSICS );
+
+	auto it = g_pScaledReferences.find( physCollide );
+	if ( it != g_pScaledReferences.end() )
+	{
+		--it->second.references;
+		if (it->second.references > 0)
+			return;
+	} else {
+		DevWarning( "UTIL_GetScaledPhysCollide: Failed to find reference counter!\n" );
+	}
+
+	auto iModel = g_pScaledCollidables.find( it->second.modelIndex );
+	if ( iModel == g_pScaledCollidables.end() )
+		return;
+
+	std::unordered_map<float, CPhysCollide*> scaledCollibales = *iModel->second;
+	auto iEntry = scaledCollibales.find( it->second.scale );
+	if ( iEntry == scaledCollibales.end() )
+		return;
+
+	scaledCollibales.erase( iEntry->first );
+	physcollision->DestroyCollide( physCollide );
+
+	if ( scaledCollibales.size() == 0 )
+		g_pScaledCollidables.erase( iModel );
+
+	DevMsg( "UTIL_RemoveScaledPhysCollide: Freed model %s\n", modelinfo->GetModelName(modelinfo->GetModel(it->second.modelIndex)) );
 }

--- a/game/client/cdll_util.h
+++ b/game/client/cdll_util.h
@@ -32,6 +32,8 @@ class IClientEntity;
 class CHudTexture;
 class CGameTrace;
 class C_BaseEntity;
+class C_BaseAnimating;
+class CPhysCollide;
 
 struct Ray_t;
 struct client_textmessage_t;
@@ -183,5 +185,13 @@ int UTIL_GetMapKeyCount( const char *pszCustomKey );
 
 // Returns true if the user has loaded any maps, false otherwise.
 bool UTIL_HasLoadedAnyMap();
+
+// SetModelScale being clientside broken fix
+// Returns the given CPhysCollide for the given model index and scale. If not found it will create it.
+CPhysCollide* UTIL_GetScaledPhysCollide( int modelIndex, float scale );
+
+// Frees the given CPhysCollide if the internal reference count reaches 0.
+// NOTE: Only supports CPhysCollide created by UTIL_GetScaledPhysCollide!
+void UTIL_RemoveScaledPhysCollide( CPhysCollide *physCollide );
 
 #endif // !UTIL_H

--- a/game/server/baseentity.cpp
+++ b/game/server/baseentity.cpp
@@ -278,6 +278,7 @@ IMPLEMENT_SERVERCLASS_ST_NOBASE( CBaseEntity, DT_BaseEntity )
 	SendPropInt		(SENDINFO(m_CollisionGroup), 5, SPROP_UNSIGNED),
 	SendPropFloat	(SENDINFO(m_flElasticity), 0, SPROP_COORD),
 	SendPropFloat	(SENDINFO(m_flShadowCastDistance), 12, SPROP_UNSIGNED ),
+	SendPropFloat	(SENDINFO(m_flGravity), 0),
 	SendPropEHandle (SENDINFO(m_hOwnerEntity)),
 	SendPropEHandle (SENDINFO(m_hEffectEntity)),
 	SendPropEHandle (SENDINFO_NAME(m_hMoveParent, moveparent)),
@@ -1831,6 +1832,7 @@ BEGIN_DATADESC_NO_BASE( CBaseEntity )
 
 	DEFINE_FIELD( m_MoveType, FIELD_CHARACTER ),
 	DEFINE_FIELD( m_MoveCollide, FIELD_CHARACTER ),
+	DEFINE_FIELD( m_flGravity, FIELD_FLOAT ),
 	DEFINE_FIELD( m_hOwnerEntity, FIELD_EHANDLE ),
 	DEFINE_FIELD( m_CollisionGroup, FIELD_INTEGER ),
 	DEFINE_PHYSPTR( m_pPhysicsObject),

--- a/game/server/baseentity.h
+++ b/game/server/baseentity.h
@@ -1668,7 +1668,7 @@ private:
 	EHANDLE			m_pBlocker;
 
 	// was pev->gravity;
-	float			m_flGravity;  // rename to m_flGravityScale;
+	CNetworkVar( float, m_flGravity );  // rename to m_flGravityScale;
 	// was pev->friction
 	CNetworkVarForDerived( float, m_flFriction );
 	CNetworkVar( float, m_flElasticity );

--- a/game/server/props.cpp
+++ b/game/server/props.cpp
@@ -5977,7 +5977,7 @@ bool UTIL_CreateScaledPhysObject( CBaseAnimating *pInstance, float flScale )
 
 		// Create a container to hold all the convexes we'll create
 		const int nNumConvex = pQuery->ConvexCount();
-		CPhysConvex **pConvexes = (CPhysConvex **) stackalloc( sizeof(CPhysConvex *) * nNumConvex );
+		CPhysPolysoup *pPolySoups = physcollision->PolysoupCreate();
 
 		// For each convex, collect the verts and create a convex from it we'll retain for later
 		for ( int i = 0; i < nNumConvex; i++ )
@@ -5986,7 +5986,6 @@ bool UTIL_CreateScaledPhysObject( CBaseAnimating *pInstance, float flScale )
 			int nNumVerts = nNumTris * 3;
 			// FIXME: Really?  stackalloc?
 			Vector *pVerts = (Vector *) stackalloc( sizeof(Vector) * nNumVerts );
-			Vector **ppVerts = (Vector **) stackalloc( sizeof(Vector *) * nNumVerts );
 			for ( int j = 0; j < nNumTris; j++ )
 			{
 				// Get all the verts for this triangle and scale them up
@@ -5994,25 +5993,19 @@ bool UTIL_CreateScaledPhysObject( CBaseAnimating *pInstance, float flScale )
 				*(pVerts+(j*3)) *= flScale;
 				*(pVerts+(j*3)+1) *= flScale;
 				*(pVerts+(j*3)+2) *= flScale;
-
-				// Setup our pointers (blech!)
-				*(ppVerts+(j*3)) = pVerts+(j*3);
-				*(ppVerts+(j*3)+1) = pVerts+(j*3)+1;
-				*(ppVerts+(j*3)+2) = pVerts+(j*3)+2;
 			}
 
-			// Convert it back to a convex
-			pConvexes[i] = physcollision->ConvexFromVerts( ppVerts, nNumVerts );
-			Assert( pConvexes[i] != NULL );
-			if ( pConvexes[i] == NULL )
-				return false;
+			for ( int j = 0; j < nNumVerts; j += 3 )
+			{
+				physcollision->PolysoupAddTriangle( pPolySoups, pVerts[j], pVerts[j + 1], pVerts[j + 2], 0 );
+			}
 		}
 
 		// Clean up
 		physcollision->DestroyQueryModel( pQuery );
 
 		// Create a collision model from all the convexes
-		pNewCollide = physcollision->ConvertConvexToCollide( pConvexes, nNumConvex );
+		pNewCollide = physcollision->ConvertPolysoupToCollide( pPolySoups, true );
 		if ( pNewCollide == NULL )
 			return false;
 	}


### PR DESCRIPTION
I've used this quite a bit to learn and find ways to optimize or solve things, so why not contribute to the main project :^

Changes:
- Geartly improve `CBaseFileSystem::FixUpPath` making the filesystem generally faster.  
- Solve `sv_parallel_sendsnapshot` crashing  
- Improved `UTIL_CreateScaledPhysObject` (If I remember correctly it was like 7x faster when originally making it)  
- Network `m_flGravity` to solve prediction errors  
- Fixed `CBaseAnimating::SetModelScale` having no clientside collisions  
I also cache the scaled `CPhysCollide` to improve performance if multiple props use the same model and scale.  

I also made a pr in the source-physics repo to solve a ivp bug that broke the entire physics engine.  
https://github.com/Source-Authors/source-physics/pull/1