### PR TITLE
[tier0] Fix a linux 64x vprof bug

### DIFF
--- a/engine/host_saverestore.cpp
+++ b/engine/host_saverestore.cpp
@@ -125,7 +125,7 @@ static bool HaveExactMap( const char *pszMapName )
 static void FinishAsyncSave()
 {
 	LOCAL_THREAD_LOCK();
-	SaveMsg( "FinishAsyncSave() (%d/%d)\n", ThreadInMainThread(), ThreadGetCurrentId() );
+	SaveMsg( "FinishAsyncSave() (%d/%lu)\n", ThreadInMainThread(), ThreadGetCurrentId() );
 	if ( g_AsyncSaveCallQueue.Count() )
 	{
 		g_AsyncSaveCallQueue.CallQueued();
@@ -628,7 +628,7 @@ int CSaveRestore::SaveGameSlot( const char *pSaveName, const char *pSaveComment,
 		Sys_Sleep( clamp( save_asyncdelay.GetInt(), 0, 3000 ) );
 	}
 
-	SaveMsg( "Start save... (%d/%d)\n", ThreadInMainThread(), ThreadGetCurrentId() );
+	SaveMsg( "Start save... (%d/%lu)\n", ThreadInMainThread(), ThreadGetCurrentId() );
 	VPROF_BUDGET( "SaveGameSlot", "Save" );
 	char			hlPath[256], name[256], *pTokenData;
 	int				tag, i, tokenSize;

--- a/filesystem/QueuedLoader.cpp
+++ b/filesystem/QueuedLoader.cpp
@@ -99,7 +99,7 @@ struct FileJob_t
 	int						m_SubmitTag;
 	int						m_nActualBytesRead;
 	LoaderError_t			m_LoaderError;
-	unsigned int			m_ThreadId;
+	ThreadId_t				m_ThreadId;
 
 	unsigned int			m_bFinished : 1;
 	unsigned int			m_bFreeTargetAfterIO : 1;

--- a/game/shared/collisionproperty.cpp
+++ b/game/shared/collisionproperty.cpp
@@ -73,7 +73,7 @@ public:
 private:
 	CTSListWithFreeList<CBaseHandle> m_DirtyEntities;
 	CThreadSpinRWLock	 m_partitionMutex;
-	uint32			 m_partitionWriteId;
+	ThreadId_t			 m_partitionWriteId;
 	CThreadLocalInt<>	 m_readLockCount;
 };
 

--- a/gcsdk/jobmgr.cpp
+++ b/gcsdk/jobmgr.cpp
@@ -1265,7 +1265,7 @@ int CJobMgr::CountJobs() const
 //-----------------------------------------------------------------------------
 void CJobMgr::CheckThreadID()
 {
-	uint unCurrentThread = ThreadGetCurrentId();
+	ThreadId_t unCurrentThread = ThreadGetCurrentId();
 
 	if ( m_unFrameFuncThreadID == 0 )
 	{

--- a/materialsystem/cmaterialsystem.cpp
+++ b/materialsystem/cmaterialsystem.cpp
@@ -349,7 +349,7 @@ void CMaterialSystem::CleanUpErrorMaterial()
 //-----------------------------------------------------------------------------
 CMaterialSystem::CMaterialSystem()
 {
-	m_nRenderThreadID = 0xFFFFFFFF;
+	m_nRenderThreadID = -1;
 	m_hAsyncLoadFileCache = NULL;
 	m_ShaderHInst = NULL;
 	m_ShaderAPIFactory = NULL;
@@ -3364,7 +3364,7 @@ void CMaterialSystem::ThreadExecuteQueuedContext( CMatQueuedRenderContext *pCont
 	m_pRenderContext.Set( &m_HardwareRenderContext );
 	pContext->EndQueue( true );
 	m_pRenderContext.Set( pSavedRenderContext );
-	m_nRenderThreadID = 0xFFFFFFFF; 
+	m_nRenderThreadID = -1; 
 }
 
 IThreadPool *CMaterialSystem::CreateMatQueueThreadPool()

--- a/materialsystem/cmaterialsystem.h
+++ b/materialsystem/cmaterialsystem.h
@@ -574,7 +574,7 @@ public:
 	MaterialLock_t							Lock();
 	void									Unlock( MaterialLock_t );
 	CMatCallQueue *							GetRenderCallQueue();
-	uint									GetRenderThreadId() const { return m_nRenderThreadID; }
+	ThreadId_t								GetRenderThreadId() const { return m_nRenderThreadID; }
 	void									UnbindMaterial( IMaterial *pMaterial );
 
 	IMaterialProxy							*DetermineProxyReplacements( IMaterial *pMaterial, KeyValues *pFallbackKeyValues );
@@ -700,7 +700,7 @@ private:
 
 	const char *							m_pForcedTextureLoadPathID;
 	FileCacheHandle_t						m_hAsyncLoadFileCache;
-	uint									m_nRenderThreadID;
+	ThreadId_t								m_nRenderThreadID;
 	bool									m_bAllocatingRenderTargets;
 	bool									m_bInStubMode;
 	bool									m_bGeneratedConfig;
@@ -708,7 +708,7 @@ private:
 	bool									m_bForcedSingleThreaded;
 	bool									m_bAllowQueuedRendering;
 	std::atomic_bool						m_bThreadHasOwnership;
-	uint									m_ThreadOwnershipID;
+	ThreadId_t								m_ThreadOwnershipID;
 
 	//---------------------------------
 

--- a/materialsystem/ctexture.cpp
+++ b/materialsystem/ctexture.cpp
@@ -3980,7 +3980,7 @@ void CTexture::DeleteIfUnreferenced()
 	if ( ThreadInMainThread() )
 	{
 		// Render thread better not be active or bad things can happen.
-		Assert( MaterialSystem()->GetRenderThreadId() == 0xFFFFFFFF );
+		Assert( MaterialSystem()->GetRenderThreadId() == -1 );
 		TextureManager()->RemoveTexture( this );
 		return;
 	}

--- a/materialsystem/imaterialsysteminternal.h
+++ b/materialsystem/imaterialsysteminternal.h
@@ -223,7 +223,7 @@ public:
 	virtual CMatCallQueue *GetRenderCallQueue() = 0;
 
 	virtual void UnbindMaterial( IMaterial *pMaterial ) = 0;
-	virtual uint GetRenderThreadId() const = 0 ;
+	virtual ThreadId_t GetRenderThreadId() const = 0 ;
 
 	virtual IMaterialProxy	*DetermineProxyReplacements( IMaterial *pMaterial, KeyValues *pFallbackKeyValues ) = 0;
 };

--- a/materialsystem/shaderapidx9/shaderdevicebase.cpp
+++ b/materialsystem/shaderapidx9/shaderdevicebase.cpp
@@ -902,7 +902,7 @@ void CShaderDeviceBase::SetCurrentThreadAsOwner()
 
 void CShaderDeviceBase::RemoveThreadOwner()
 {
-	m_dwThreadId = 0xFFFFFFFF;
+	m_dwThreadId = -1;
 }
 
 bool CShaderDeviceBase::ThreadOwnsDevice()

--- a/materialsystem/shaderapidx9/shaderdevicebase.h
+++ b/materialsystem/shaderapidx9/shaderdevicebase.h
@@ -184,7 +184,7 @@ protected:
 
 	int	m_nWindowWidth;
 	int m_nWindowHeight;
-	uint32 m_dwThreadId;
+	ThreadId_t m_dwThreadId;
 };
 
 

--- a/materialsystem/texturemanager.cpp
+++ b/materialsystem/texturemanager.cpp
@@ -748,8 +748,8 @@ protected:
 	friend class AsyncReader;
 	AsyncReader* m_pAsyncReader;
 
-	uint m_nAsyncLoadThread;
-	uint m_nAsyncReadThread;
+	ThreadId_t m_nAsyncLoadThread;
+	ThreadId_t m_nAsyncReadThread;
 
 	int m_iSuspendTextureStreaming;
 };
@@ -1097,7 +1097,7 @@ private:
 
 		s_TextureManager.m_nAsyncLoadThread = ThreadGetCurrentId();
 		( ( AsyncLoader* )_this )->ThreadLoader_Main();
-		s_TextureManager.m_nAsyncLoadThread = 0xFFFFFFFF;
+		s_TextureManager.m_nAsyncLoadThread = -1;
 		return 0;
 	}
 
@@ -1397,7 +1397,7 @@ private:
 
 		s_TextureManager.m_nAsyncReadThread = ThreadGetCurrentId();
 		( ( AsyncReader* ) _this )->ThreadReader_Main();
-		s_TextureManager.m_nAsyncReadThread = 0xFFFFFFFF;
+		s_TextureManager.m_nAsyncReadThread = -1;
 		return 0;
 	}
 
@@ -1422,8 +1422,8 @@ CTextureManager::CTextureManager( void )
 , m_TextureExcludes( true )
 , m_PendingAsyncLoads( true ) 
 , m_textureStreamingRequests( DefLessFunc( ITextureInternal* ) )
-, m_nAsyncLoadThread( 0xFFFFFFFF )
-, m_nAsyncReadThread( 0xFFFFFFFF )
+, m_nAsyncLoadThread( -1 )
+, m_nAsyncReadThread( -1 )
 {
 	m_iNextTexID = 0;
 	m_nFlags = 0;

--- a/public/gcsdk/jobmgr.h
+++ b/public/gcsdk/jobmgr.h
@@ -301,7 +301,7 @@ private:
 	friend void Job_RegisterJobType( const JobType_t *pJobType );
 
 	JobID_t m_unNextJobID;
-	uint m_unFrameFuncThreadID; // the thread is JobMgr is working in
+	ThreadId_t m_unFrameFuncThreadID; // the thread is JobMgr is working in
 	bool m_bProfiling;
 	bool m_bIsShuttingDown;
 	int m_cErrorsToReport;

--- a/public/tier0/vprof.h
+++ b/public/tier0/vprof.h
@@ -400,8 +400,8 @@ public:
 	void Start();
 	void Stop();
 
-	void SetTargetThreadId( unsigned id ) { m_TargetThreadId = id; }
-	unsigned GetTargetThreadId() const { return m_TargetThreadId; }
+	void SetTargetThreadId( ThreadId_t id ) { m_TargetThreadId = id; }
+	ThreadId_t GetTargetThreadId() const { return m_TargetThreadId; }
 	bool InTargetThread() const { return ( m_TargetThreadId == ThreadGetCurrentId() ); }
 
 	void EnterScope( const tchar *pszName, int detailLevel, const tchar *pBudgetGroupName, bool bAssertAccounted );

--- a/public/tier0/vprof.h
+++ b/public/tier0/vprof.h
@@ -545,7 +545,7 @@ protected:
 	tchar *m_CounterNames[MAXCOUNTERS];
 	int m_NumCounters;
 
-	unsigned m_TargetThreadId;
+	ThreadId_t m_TargetThreadId;
 
 	StreamOut_t				m_pOutputStream;
 };

--- a/tier0/thread.cpp
+++ b/tier0/thread.cpp
@@ -15,7 +15,7 @@
 #include "tier0/dbg.h"
 #include "tier0/threadtools.h"
 
-unsigned long Plat_GetCurrentThreadID()
+ThreadId_t Plat_GetCurrentThreadID()
 {
 	return ThreadGetCurrentId();
 }


### PR DESCRIPTION
Fixed a vprof bug.
On 64x linux, vprof would fail since the `m_TargetThreadId` would use the wrong size.  
This was a bug that I noticed in gmod which also got fixed there.  