### PR TITLE
[engine] Fix a downcast issue possibly causing physics bugs

### DIFF
--- a/engine/cmodel_private.h
+++ b/engine/cmodel_private.h
@@ -98,13 +98,13 @@ struct cbrushside_t
 	unsigned short bBevel;							// is the side a bevel plane?
 };
 
-#define NUMSIDES_BOXBRUSH	0xFFFF
+#define NUMSIDES_BOXBRUSH	-1
 
 struct cbrush_t
 {
 	int				contents;
-	unsigned short	numsides;
-	unsigned short	firstbrushside;
+	int				numsides;
+	int				firstbrushside;
 
 	inline int GetBox() const { return firstbrushside; }
 	// dimhotepus: int -> unsigned short


### PR DESCRIPTION
Fixed a downcast issue that could possibly cause physics issues in the future
This was a bug that was found in gmod & fixed there, if the MAX_MAP_BRUSHSIDES was raised, any brush that had brush sides above the limit would have no collisions.  
So this would only be a issue if you were to raise it.  