### PR TITLE
engine: make usage of NET_GetLastError const

### DIFF
--- a/engine/net_ws.cpp
+++ b/engine/net_ws.cpp
@@ -448,7 +448,7 @@ socket_handle NET_OpenSocket ( const char *net_interface, int& port, int protoco
 
 	if ( newsocket == -1 )
 	{
-		int net_error = NET_GetLastError();
+		const int net_error = NET_GetLastError();
 		if ( net_error != WSAEAFNOSUPPORT )
 			Warning ("NET_OpenSocket: socket(protocol %d) failed: %s.\n", protocol, NET_ErrorString(net_error));
 
@@ -702,7 +702,7 @@ int NET_ReceiveStream( socket_handle nSock, char * buf, int len, int flags )
 	int ret = VCRHook_recv( nSock, buf, len, flags );
 	if ( ret == -1 )
 	{
-		int net_error = NET_GetLastError();
+		const int net_error = NET_GetLastError();
 		if ( net_error == WSAEWOULDBLOCK || 
 			 net_error == WSAENOTCONN )
 		{


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/Source-Authors/Obsoletium/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/Source-Authors/Obsoletium/blob/HEAD/docs/contributing/PULL_REQUESTS.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests pass.

If you believe this PR should be highlighted in the Obsoletium CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Small thing for consistency since it was done for some but not all