### PR TITLE
filesystem: use a RWLock instead

### DIFF
--- a/filesystem/basefilesystem.cpp
+++ b/filesystem/basefilesystem.cpp
@@ -1458,7 +1458,7 @@ void CBaseFileSystem::AddSearchPath( const char *pPath, const char *pathID, Sear
 //-----------------------------------------------------------------------------
 int CBaseFileSystem::GetSearchPath( const char *pathID, bool bGetPackFiles, OUT_Z_CAP(maxLenInChars) char *pDest, intp maxLenInChars )
 {
-	AUTO_LOCK( m_SearchPathsMutex );
+	AUTO_LOCK_READ( m_SearchPathsMutex );
 
 	// Build up result into string object
 	// dimhotepus: Use std::string and reserve capacity. 
@@ -1582,7 +1582,7 @@ CBaseFileSystem::CSearchPath *CBaseFileSystem::FindWritePath( const char *pFilen
 {
 	CUtlSymbol lookup = g_PathIDTable.AddString( pathID );
 
-	AUTO_LOCK( m_SearchPathsMutex );
+	AUTO_LOCK_READ( m_SearchPathsMutex );
 
 	// a pathID has been specified, find the first match in the path list
 	intp c = m_SearchPaths.Count();
@@ -1964,7 +1964,7 @@ bool CBaseFileSystem::UnzipFile( const char *pFileName, const char *pPath, const
 //-----------------------------------------------------------------------------
 void CBaseFileSystem::RemoveAllSearchPaths( void )
 {
-	AUTO_LOCK( m_SearchPathsMutex );
+	AUTO_LOCK_WRITE( m_SearchPathsMutex );
 	m_SearchPaths.Purge();
 }
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/Source-Authors/Obsoletium/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/Source-Authors/Obsoletium/blob/HEAD/docs/contributing/PULL_REQUESTS.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests pass.

If you believe this PR should be highlighted in the Obsoletium CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Still have to do performance tests