### PR TITLE
vphysics: expose new functions to support multiple physics environments

### DIFF
--- a/game/shared/physics_shared.cpp
+++ b/game/shared/physics_shared.cpp
@@ -500,10 +500,7 @@ void PhysDestroyObject( IPhysicsObject *pObject, CBaseEntity *pEntity )
 		g_EntityCollisionHash->RemoveAllPairsForObject( pEntity );
 	}
 
-	if ( physenv )
-	{
-		physenv->DestroyObject( pObject );
-	}
+	DestroyPhysicsObject( pObject );
 }
 
 static void AddSurfacepropFile( const char *pFileName, IPhysicsSurfaceProps *pProps, IFileSystem *pFileSystem )

--- a/public/vphysics_interface.h
+++ b/public/vphysics_interface.h
@@ -863,8 +863,19 @@ public:
 	// dumps info about the object to Msg()
 	virtual void			OutputDebugInfo() const = 0;
 
+	// returns the buoyancy of the object.
+	// newly added by Valve in new builds since it was requested by Rubat to solve https://github.com/Facepunch/garrysmod-issues/issues/5696
+	virtual float			GetBuoyancyRatio( void ) const = 0;
+
+	// returns the environment this object belongs to
+	virtual IPhysicsEnvironment *GetEnvironment( void ) const = 0;
 };
 
+// Helper function - destroys the given object using the right environment
+static inline void DestroyPhysicsObject( IPhysicsObject* pObject )
+{
+	pObject->GetEnvironment()->DestroyObject( pObject );
+}
 
 abstract_class IPhysicsSpring
 {

--- a/vphysics/physics_object.cpp
+++ b/vphysics/physics_object.cpp
@@ -1454,6 +1454,12 @@ void CPhysicsObject::OutputDebugInfo() const
 	}
 }
 
+IPhysicsEnvironment *CPhysicsObject::GetEnvironment() const
+{
+	// Same as GetVPhysicsEnvironment but this function is exposed for the game dlls
+	return (CPhysicsEnvironment *) (m_pObject->get_environment()->client_data);
+}
+
 bool CPhysicsObject::IsAttachedToConstraint( bool bExternalOnly ) const
 {
 	if ( m_pObject )

--- a/vphysics/physics_object.h
+++ b/vphysics/physics_object.h
@@ -187,6 +187,10 @@ public:
 
 	void			OutputDebugInfo() const override;
 
+	[[nodiscard]] float	GetBuoyancyRatio( void ) const override { return m_buoyancyRatio; }
+
+	[[nodiscard]] IPhysicsEnvironment	*GetEnvironment() const override;
+
 	// local functions
 	[[nodiscard]] inline	IVP_Real_Object *GetObject( void ) const { return m_pObject; }
 	// dimhotepus: int -> unsigned short.
@@ -202,7 +206,6 @@ public:
 
 	[[nodiscard]] inline intp		GetActiveIndex( void ) const { return m_activeIndex; }
 	inline void		SetActiveIndex( intp index ) { m_activeIndex = index; }
-	[[nodiscard]] inline float	GetBuoyancyRatio( void ) const { return m_buoyancyRatio; }
 	// returns true if the mass center is set to the default for the collision model
 	[[nodiscard]] bool			IsMassCenterAtDefault() const;
 


### PR DESCRIPTION
\- [+] Exposed `IPhysicsObject::GetBuoyancyRatio` (was added in new vphysics versions) & `IPhysicsObject::GetEnvironment`
\- [#] Made `PhysDestroyObject` make use of the new `IPhysicsObject::GetEnvironment` to support entities with phys object possibly from other environments

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/Source-Authors/Obsoletium/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/Source-Authors/Obsoletium/blob/HEAD/docs/contributing/PULL_REQUESTS.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests pass.

If you believe this PR should be highlighted in the Obsoletium CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
