### PR TITLE
engine: remove obsolete flags causing false positive 7.1 breaking audio for my headset

### DIFF
--- a/engine/audio/private/snd_dev_xaudio.cpp
+++ b/engine/audio/private/snd_dev_xaudio.cpp
@@ -378,10 +378,7 @@ static bool GetDefaultAudioDeviceFormFactor(
     // May fail.
     if (device_physical_speakers.as_uint(physical_speakers_mask)) {
       if ((physical_speakers_mask & KSAUDIO_SPEAKER_7POINT1_SURROUND) ==
-              KSAUDIO_SPEAKER_7POINT1_SURROUND ||
-          // Obsolete, but still.
-          (physical_speakers_mask & KSAUDIO_SPEAKER_7POINT1) &
-              KSAUDIO_SPEAKER_7POINT1) {
+              KSAUDIO_SPEAKER_7POINT1_SURROUND) {
         form_factor = AudioDeviceFormFactor::Digital7Dot1Surround;
         return true;
       }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/Source-Authors/Obsoletium/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/Source-Authors/Obsoletium/blob/HEAD/docs/contributing/PULL_REQUESTS.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests pass.

If you believe this PR should be highlighted in the Obsoletium CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
I had XAudio2 completely break down since it falsely thought my headset/sound card was 7 point, when it isn't.
Removing this obsolete code seems to solve the issue