### PR TITLE
repo: properly add ignore dirty to all submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,19 +1,24 @@
 [submodule "thirdparty/SDL"]
 	path = thirdparty/SDL
 	url = git@github.com:Source-Authors/SDL.git
+	ignore = dirty
 [submodule "thirdparty/stb"]
 	path = thirdparty/stb
 	url = git@github.com:Source-Authors/stb.git
+	ignore = dirty
 [submodule "thirdparty/DirectXMath"]
 	path = thirdparty/DirectXMath
 	url = git@github.com:Source-Authors/DirectXMath.git
+	ignore = dirty
 [submodule "thirdparty/zlib"]
 	path = thirdparty/zlib
 	url = git@github.com:Source-Authors/zlib.git
 	ignore = dirty
+	ignore = dirty
 [submodule "thirdparty/libpng"]
 	path = thirdparty/libpng
 	url = git@github.com:Source-Authors/libpng.git
+	ignore = dirty
 [submodule "thirdparty/libjpeg-turbo"]
 	path = thirdparty/libjpeg-turbo
 	url = git@github.com:Source-Authors/libjpeg-turbo.git
@@ -22,6 +27,7 @@
 	path = thirdparty/openvr
 	url = git@github.com:Source-Authors/openvr.git
 	branch = 061cf411ee1125fe4b7cdf3837451a1c6a32a3c8
+	ignore = dirty
 [submodule "thirdparty/protobuf"]
 	path = thirdparty/protobuf
 	url = git@github.com:Source-Authors/protobuf.git
@@ -29,42 +35,53 @@
 [submodule "thirdparty/bzip2"]
 	path = thirdparty/bzip2
 	url = git@github.com:Source-Authors/bzip2.git
+	ignore = dirty
 [submodule "thirdparty/cryptopp"]
 	path = thirdparty/cryptopp
 	url = git@github.com:Source-Authors/cryptopp.git
+	ignore = dirty
 [submodule "ivp"]
 	path = ivp
 	url = git@github.com:Source-Authors/source-physics.git
 [submodule "thirdparty/snappy"]
 	path = thirdparty/snappy
 	url = git@github.com:Source-Authors/snappy.git
+	ignore = dirty
 [submodule "external/vpc"]
 	path = external/vpc
 	url = git@github.com:Source-Authors/vpc.git
 [submodule "thirdparty/mpaheaderinfo"]
 	path = thirdparty/mpaheaderinfo
 	url = git@github.com:Source-Authors/mpaheaderInfo.git
+	ignore = dirty
 [submodule "thirdparty/minimp3"]
 	path = thirdparty/minimp3
 	url = git@github.com:Source-Authors/minimp3.git
+	ignore = dirty
 [submodule "thirdparty/celt"]
 	path = thirdparty/celt
 	url = git@github.com:Source-Authors/celt.git
+	ignore = dirty
 [submodule "thirdparty/speex"]
 	path = thirdparty/speex
 	url = git@github.com:Source-Authors/speex.git
+	ignore = dirty
 [submodule "thirdparty/zip-utils"]
 	path = thirdparty/zip-utils
 	url = git@github.com:Source-Authors/zip-utils.git
+	ignore = dirty
 [submodule "thirdparty/speedtree"]
 	path = thirdparty/speedtree
 	url = git@github.com:Source-Authors/SpeedTree.git
+	ignore = dirty
 [submodule "thirdparty/nvtristrip"]
 	path = thirdparty/nvtristrip
 	url = git@github.com:Source-Authors/NvTriStrip.git
+	ignore = dirty
 [submodule "thirdparty/7zip"]
 	path = thirdparty/7zip
 	url = git@github.com:Source-Authors/7zip.git
+	ignore = dirty
 [submodule "thirdparty/lua"]
 	path = thirdparty/lua
 	url = git@github.com:Source-Authors/Lua.git
@@ -72,6 +89,7 @@
 [submodule "thirdparty/shadercompile"]
 	path = thirdparty/shadercompile
 	url = git@github.com:Source-Authors/ShaderCompile.git
+	ignore = dirty
 [submodule "thirdparty/squirrel"]
 	path = thirdparty/squirrel
 	url = git@github.com:Source-Authors/squirrel.git


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/Source-Authors/Obsoletium/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/Source-Authors/Obsoletium/blob/HEAD/docs/contributing/PULL_REQUESTS.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests pass.

If you believe this PR should be highlighted in the Obsoletium CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
This has been missing from a few submodules which now had been causing issues for me