### PR TITLE
engine: fix an overflow if combination of MAX_EDICT_BITS & DELTASIZE_BITS is too much

### DIFF
--- a/engine/sv_ents_write.cpp
+++ b/engine/sv_ents_write.cpp
@@ -854,7 +854,8 @@ void CBaseServer::WriteDeltaEntities( CBaseClient *client, CClientFrame *to, CCl
 	bf_write savepos = *u.m_pBuf;
 
 	// Save room for number of headers to parse, too
-	u.m_pBuf->WriteUBitLong ( 0, MAX_EDICT_BITS+DELTASIZE_BITS+1 );	
+	CBitVec<MAX_EDICT_BITS+DELTASIZE_BITS+1> pHeaderBits; // RaphaelIT7: Exists just to pass nothing to WriteBits (all bits are 0 soo it'll be fine)
+	u.m_pBuf->WriteBits( pHeaderBits.Base(), pHeaderBits.GetNumBits() ); // RaphaelIT7: kept it as it should be faster than 3 WriteUBitLong calls
 		
 	intp startbit = u.m_pBuf->GetNumBitsWritten();
 


### PR DESCRIPTION
Nice to have to avoid future issues, as I've encountered this/went over 32 bits causing WriteUBitLong to fail.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/Source-Authors/Obsoletium/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/Source-Authors/Obsoletium/blob/HEAD/docs/contributing/PULL_REQUESTS.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that tests pass.

If you believe this PR should be highlighted in the Obsoletium CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
